### PR TITLE
Add custom SSLContext parameter to EmailServerCredentials

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+- Add custom SSLContext parameter to EmailServerCredentials - [#38](https://github.com/PrefectHQ/prefect-email/pull/38)
+
 ### Added
 
 ### Changed

--- a/prefect_email/credentials.py
+++ b/prefect_email/credentials.py
@@ -15,7 +15,7 @@ class SMTPType(Enum):
     """
 
     SSL = 465
-    STARTTLS = 465
+    STARTTLS = 587
     INSECURE = 25
 
 

--- a/prefect_email/credentials.py
+++ b/prefect_email/credentials.py
@@ -15,7 +15,7 @@ class SMTPType(Enum):
     """
 
     SSL = 465
-    STARTTLS = 587
+    STARTTLS = 465
     INSECURE = 25
 
 

--- a/prefect_email/credentials.py
+++ b/prefect_email/credentials.py
@@ -3,7 +3,7 @@
 import ssl
 from enum import Enum
 from smtplib import SMTP, SMTP_SSL
-from typing import Any, Optional, Union
+from typing import Optional, Union
 
 from prefect.blocks.core import Block
 from pydantic import SecretStr
@@ -78,6 +78,7 @@ class EmailServerCredentials(Block):
             keys from the built-in SMTPServer Enum members, like "gmail".
         smtp_type: Either "SSL", "STARTTLS", or "INSECURE".
         smtp_port: If provided, overrides the smtp_type's default port number.
+        context: If provided, overrides the default ssl.SSLContext
 
     Example:
         Load stored email server credentials:
@@ -95,7 +96,7 @@ class EmailServerCredentials(Block):
     smtp_server: Optional[Union[str, SMTPServer]] = SMTPServer.GMAIL
     smtp_type: Optional[Union[str, SMTPType]] = SMTPType.SSL
     smtp_port: Optional[int] = None
-    context: Optional[Any] = None
+    context: Optional[object] = None
 
     def get_server(self) -> SMTP:
         """

--- a/prefect_email/credentials.py
+++ b/prefect_email/credentials.py
@@ -3,8 +3,7 @@
 import ssl
 from enum import Enum
 from smtplib import SMTP, SMTP_SSL
-from ssl import SSLContext
-from typing import Optional, Union
+from typing import Any, Optional, Union
 
 from prefect.blocks.core import Block
 from pydantic import SecretStr
@@ -96,7 +95,7 @@ class EmailServerCredentials(Block):
     smtp_server: Optional[Union[str, SMTPServer]] = SMTPServer.GMAIL
     smtp_type: Optional[Union[str, SMTPType]] = SMTPType.SSL
     smtp_port: Optional[int] = None
-    context: Optional[SSLContext] = None
+    context: Optional[Any] = None
 
     def get_server(self) -> SMTP:
         """

--- a/prefect_email/credentials.py
+++ b/prefect_email/credentials.py
@@ -3,6 +3,7 @@
 import ssl
 from enum import Enum
 from smtplib import SMTP, SMTP_SSL
+from ssl import SSLContext
 from typing import Optional, Union
 
 from prefect.blocks.core import Block
@@ -95,6 +96,7 @@ class EmailServerCredentials(Block):
     smtp_server: Optional[Union[str, SMTPServer]] = SMTPServer.GMAIL
     smtp_type: Optional[Union[str, SMTPType]] = SMTPType.SSL
     smtp_port: Optional[int] = None
+    context: Optional[SSLContext] = None
 
     def get_server(self) -> SMTP:
         """
@@ -133,7 +135,9 @@ class EmailServerCredentials(Block):
         if smtp_type == SMTPType.INSECURE:
             server = SMTP(smtp_server, smtp_port)
         else:
-            context = ssl.create_default_context()
+            context = self.context
+            if context is None:
+                context = ssl.create_default_context()
             if smtp_type == SMTPType.SSL:
                 server = SMTP_SSL(smtp_server, smtp_port, context=context)
             elif smtp_type == SMTPType.STARTTLS:

--- a/prefect_email/credentials.py
+++ b/prefect_email/credentials.py
@@ -1,8 +1,8 @@
 """Credential classes used to perform authenticated interactions with email services"""
 
-import ssl
 from enum import Enum
 from smtplib import SMTP, SMTP_SSL
+from ssl import SSLContext, create_default_context
 from typing import Optional, Union
 
 from prefect.blocks.core import Block
@@ -78,7 +78,6 @@ class EmailServerCredentials(Block):
             keys from the built-in SMTPServer Enum members, like "gmail".
         smtp_type: Either "SSL", "STARTTLS", or "INSECURE".
         smtp_port: If provided, overrides the smtp_type's default port number.
-        context: If provided, overrides the default ssl.SSLContext
 
     Example:
         Load stored email server credentials:
@@ -96,11 +95,14 @@ class EmailServerCredentials(Block):
     smtp_server: Optional[Union[str, SMTPServer]] = SMTPServer.GMAIL
     smtp_type: Optional[Union[str, SMTPType]] = SMTPType.SSL
     smtp_port: Optional[int] = None
-    context: Optional[object] = None
 
-    def get_server(self) -> SMTP:
+    def get_server(self, ssl_context: SSLContext = None) -> SMTP:
         """
         Gets an authenticated SMTP server.
+
+        Args:
+            ssl_context: A custom SSLContext to pass to the SMTP server
+                If None, then ssl.create_default_context() is used
 
         Returns:
             SMTP: An authenticated SMTP server.
@@ -128,21 +130,18 @@ class EmailServerCredentials(Block):
             smtp_server = smtp_server.value
 
         smtp_type = _cast_to_enum(self.smtp_type, SMTPType, restrict=True)
-        smtp_port = self.smtp_port
-        if smtp_port is None:
-            smtp_port = smtp_type.value
+        smtp_port = self.smtp_port or smtp_type.value
 
         if smtp_type == SMTPType.INSECURE:
             server = SMTP(smtp_server, smtp_port)
         else:
-            context = self.context
-            if context is None:
-                context = ssl.create_default_context()
+            if ssl_context is None:
+                ssl_context = create_default_context()
             if smtp_type == SMTPType.SSL:
-                server = SMTP_SSL(smtp_server, smtp_port, context=context)
+                server = SMTP_SSL(smtp_server, smtp_port, context=ssl_context)
             elif smtp_type == SMTPType.STARTTLS:
                 server = SMTP(smtp_server, smtp_port)
-                server.starttls(context=context)
+                server.starttls(context=ssl_context)
             server.login(self.username, self.password.get_secret_value())
 
         return server

--- a/tests/test_credentials.py
+++ b/tests/test_credentials.py
@@ -1,3 +1,5 @@
+import ssl
+
 import pytest
 
 from prefect_email.credentials import (
@@ -32,17 +34,38 @@ def test_cast_to_enum_restrict_error():
     "smtp_server", ["gmail", "GMAIL", "smtp.gmail.com", "SMTP.GMAIL.COM"]
 )
 @pytest.mark.parametrize("smtp_type", ["SSL", "STARTTLS", "ssl", "StartTLS"])
-def test_email_server_credentials_get_server(smtp_server, smtp_type, smtp):
+@pytest.mark.parametrize("ssl_context", [None, ssl.create_default_context()])
+def test_email_server_credentials_get_server(smtp_server, smtp_type, smtp, ssl_context):
     server = EmailServerCredentials(
         username="username",
         password="password",
         smtp_server=smtp_server,
         smtp_type=smtp_type,
-    ).get_server()
+    ).get_server(ssl_context=ssl_context)
     assert server.username == "username"
     assert server.password == "password"
     assert server.server.lower() == "smtp.gmail.com"
     assert server.port == 465
+    default_context = ssl.create_default_context()
+    assert server.context.protocol == default_context.protocol
+    assert server.context.options == default_context.options
+    assert server.context.get_ciphers() == default_context.get_ciphers()
+    assert server.context.verify_flags == default_context.verify_flags
+
+
+def test_email_server_credentials_get_server_custom_context(smtp):
+    custom_context = ssl.SSLContext(protocol=ssl.PROTOCOL_TLS_SERVER)
+    custom_context.options = ssl.OP_NO_TICKET
+    server = EmailServerCredentials(
+        username="username",
+        password="password",
+    ).get_server(ssl_context=custom_context)
+    assert server.username == "username"
+    assert server.password == "password"
+    assert server.server.lower() == "smtp.gmail.com"
+    assert server.port == 465
+    assert server.context.protocol == custom_context.protocol
+    assert server.context.options == custom_context.options
 
 
 def test_email_server_credentials_get_server_error(smtp):


### PR DESCRIPTION
Closes #37

### Example
EmailServerCredentials now has an optional parameter ("context") by which a custom ssl.SSLContext can be passed in. e.g.

```
context = ssl.SSLContext()
## to enable self-signed certificates to be accepted by smtplib
context.load_verify_locations('path to server cert PEM')
server = EmailServerCredentials(
    username="username",
    password="password",
    smtp_server=smtp_server,
    smtp_type=smtp_type,
    context=context
).get_server()
```

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [x] This pull request references any related issue by including "Closes #<ISSUE_NUMBER>"
	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect-email/issues/new/choose) first.
- [x] This pull request includes tests or only affects documentation.
- [x] Summarized PR's changes in [CHANGELOG.md](https://github.com/PrefectHQ/prefect-email/blob/main/CHANGELOG.md)
