### PR TITLE
Fix STARTTLS to use port 587

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+- Fix STARTTLS to use port 587 [#41](https://github.com/PrefectHQ/prefect-email/pull/41)
+
 ### Added
 
 ### Changed

--- a/prefect_email/credentials.py
+++ b/prefect_email/credentials.py
@@ -15,7 +15,7 @@ class SMTPType(Enum):
     """
 
     SSL = 465
-    STARTTLS = 465
+    STARTTLS = 587
     INSECURE = 25
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -31,6 +31,9 @@ class SMTPMock:
         self.username = username
         self.password = password
 
+    def starttls(self, context=None):
+        self.context = context
+
 
 @pytest.fixture
 def smtp(monkeypatch):

--- a/tests/test_credentials.py
+++ b/tests/test_credentials.py
@@ -31,8 +31,11 @@ def test_cast_to_enum_restrict_error():
 @pytest.mark.parametrize(
     "smtp_server", ["gmail", "GMAIL", "smtp.gmail.com", "SMTP.GMAIL.COM"]
 )
-@pytest.mark.parametrize("smtp_type", ["SSL", "STARTTLS", "ssl", "StartTLS"])
-def test_email_server_credentials_get_server(smtp_server, smtp_type, smtp):
+@pytest.mark.parametrize(
+    "smtp_type, smtp_port",
+    [("SSL", 465), ("STARTTLS", 587), ("ssl", 465), ("StartTLS", 587)],
+)
+def test_email_server_credentials_get_server(smtp_server, smtp_type, smtp_port, smtp):
     server = EmailServerCredentials(
         username="username",
         password="password",
@@ -42,7 +45,7 @@ def test_email_server_credentials_get_server(smtp_server, smtp_type, smtp):
     assert server.username == "username"
     assert server.password == "password"
     assert server.server.lower() == "smtp.gmail.com"
-    assert server.port == 465
+    assert server.port == smtp_port
 
 
 def test_email_server_credentials_get_server_error(smtp):


### PR DESCRIPTION
SMTPType.STARTTLS was set to 465 as its default port  - it is actually 587. Tests and the mock SMTPMock object were also changed because this uncovered a bug aka a code path that wasn't actually ever tested.

<!-- Link to issue -->
Closes #39

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [x] This pull request references any related issue by including "Closes #<ISSUE_NUMBER>"
	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect-email/issues/new/choose) first.
- [x] This pull request includes tests or only affects documentation.
- [x] Summarized PR's changes in [CHANGELOG.md](https://github.com/PrefectHQ/prefect-email/blob/main/CHANGELOG.md)
