### PR TITLE
Made EmailServerCredentials username/password optional

### DIFF
--- a/.cruft.json
+++ b/.cruft.json
@@ -1,6 +1,6 @@
 {
   "template": "https://github.com/PrefectHQ/prefect-collection-template",
-  "commit": "bec430a3d32d97d60da3db5964e14d9056f4751b",
+  "commit": "3557dc4b7c0f84a736a78c1c0ec44cc3314c6460",
   "context": {
     "cookiecutter": {
       "full_name": "Prefect Technologies, Inc.",

--- a/prefect_email/credentials.py
+++ b/prefect_email/credentials.py
@@ -3,7 +3,7 @@
 import ssl
 from enum import Enum
 from smtplib import SMTP, SMTP_SSL
-from typing import Optional, Union
+from typing import Union
 
 from prefect.blocks.core import Block
 from pydantic import SecretStr
@@ -73,9 +73,9 @@ class EmailServerCredentials(Block):
 
     Attributes:
         username: The username to use for authentication to the server.
-            Unnecessary if SMTP login is not required
+            Unnecessary if SMTP login is not required.
         password: The password to use for authentication to the server.
-            Unnecessary if SMTP login is not required
+            Unnecessary if SMTP login is not required.
         smtp_server: Either the hostname of the SMTP server, or one of the
             keys from the built-in SMTPServer Enum members, like "gmail".
         smtp_type: Either "SSL", "STARTTLS", or "INSECURE".
@@ -92,11 +92,11 @@ class EmailServerCredentials(Block):
     _block_type_name = "Email Server Credentials"
     _logo_url = "https://images.ctfassets.net/gm98wzqotmnx/3PcxFuO9XUqs7wU9MiUBMg/ca740e27815d15528373aced667f58b9/email__1_.png?h=250"  # noqa
 
-    username: Optional[str] = None
-    password: Optional[SecretStr] = ""
-    smtp_server: Optional[Union[str, SMTPServer]] = SMTPServer.GMAIL
-    smtp_type: Optional[Union[str, SMTPType]] = SMTPType.SSL
-    smtp_port: Optional[int] = None
+    username: str = None
+    password: SecretStr = SecretStr("")
+    smtp_server: Union[str, SMTPServer] = SMTPServer.GMAIL
+    smtp_type: Union[str, SMTPType] = SMTPType.SSL
+    smtp_port: int = None
 
     def get_server(self) -> SMTP:
         """

--- a/prefect_email/credentials.py
+++ b/prefect_email/credentials.py
@@ -73,7 +73,9 @@ class EmailServerCredentials(Block):
 
     Attributes:
         username: The username to use for authentication to the server.
+            Unnecessary if SMTP login is not required
         password: The password to use for authentication to the server.
+            Unnecessary if SMTP login is not required
         smtp_server: Either the hostname of the SMTP server, or one of the
             keys from the built-in SMTPServer Enum members, like "gmail".
         smtp_type: Either "SSL", "STARTTLS", or "INSECURE".
@@ -90,8 +92,8 @@ class EmailServerCredentials(Block):
     _block_type_name = "Email Server Credentials"
     _logo_url = "https://images.ctfassets.net/gm98wzqotmnx/3PcxFuO9XUqs7wU9MiUBMg/ca740e27815d15528373aced667f58b9/email__1_.png?h=250"  # noqa
 
-    username: str
-    password: SecretStr
+    username: Optional[str] = None
+    password: Optional[SecretStr] = ""
     smtp_server: Optional[Union[str, SMTPServer]] = SMTPServer.GMAIL
     smtp_type: Optional[Union[str, SMTPType]] = SMTPType.SSL
     smtp_port: Optional[int] = None
@@ -139,6 +141,7 @@ class EmailServerCredentials(Block):
             elif smtp_type == SMTPType.STARTTLS:
                 server = SMTP(smtp_server, smtp_port)
                 server.starttls(context=context)
-            server.login(self.username, self.password.get_secret_value())
+            if self.username is not None:
+                server.login(self.username, self.password.get_secret_value())
 
         return server

--- a/prefect_email/credentials.py
+++ b/prefect_email/credentials.py
@@ -3,7 +3,7 @@
 import ssl
 from enum import Enum
 from smtplib import SMTP, SMTP_SSL
-from typing import Union
+from typing import Optional, Union
 
 from prefect.blocks.core import Block
 from pydantic import SecretStr
@@ -92,11 +92,11 @@ class EmailServerCredentials(Block):
     _block_type_name = "Email Server Credentials"
     _logo_url = "https://images.ctfassets.net/gm98wzqotmnx/3PcxFuO9XUqs7wU9MiUBMg/ca740e27815d15528373aced667f58b9/email__1_.png?h=250"  # noqa
 
-    username: str = None
+    username: Optional[str] = None
     password: SecretStr = SecretStr("")
     smtp_server: Union[str, SMTPServer] = SMTPServer.GMAIL
     smtp_type: Union[str, SMTPType] = SMTPType.SSL
-    smtp_port: int = None
+    smtp_port: Optional[int] = None
 
     def get_server(self) -> SMTP:
         """

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -12,3 +12,4 @@ mock; python_version < '3.8'
 mkdocs-gen-files
 interrogate
 coverage
+pillow


### PR DESCRIPTION
EmailServerCredentials username/password were mandatory settings which makes no sense if an INSECURE SMTP server (aka port 25) is being used - no need to login etc.  

Also potentially possible are secured SMTP servers (e.g. through SSL client/server certificates) that require no login step and server.login() would have caused problems.

<!-- Link to issue -->
Closes #40

### Example
```
    server = EmailServerCredentials(
        smtp_server="a.public.server",
        smtp_type=SMTPType.INSECURE
    ).get_server()
```

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [ ] This pull request references any related issue by including "Closes #<ISSUE_NUMBER>"
	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect-email/issues/new/choose) first.
- [ ] This pull request includes tests or only affects documentation.
- [ ] Summarized PR's changes in [CHANGELOG.md](https://github.com/PrefectHQ/prefect-email/blob/main/CHANGELOG.md)
