### PR TITLE
add unverified-context to credentials

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- `unverified_context` parameter added to email credentials to support unverified servers.
+
 ### Changed
 
 ### Deprecated

--- a/prefect_email/credentials.py
+++ b/prefect_email/credentials.py
@@ -132,6 +132,13 @@ class EmailServerCredentials(Block):
         title="SMTP Port",
     )
 
+    unverified_context: Optional[bool] = Field(
+        default=False,
+        description=(
+            "Unverified context should be used or not. By default this is False"
+        ),
+    )
+
     @validator("smtp_server", pre=True)
     def _cast_smtp_server(cls, value):
         """
@@ -185,7 +192,11 @@ class EmailServerCredentials(Block):
         if smtp_type == SMTPType.INSECURE:
             server = SMTP(smtp_server, smtp_port)
         else:
-            context = ssl.create_default_context()
+            context = (
+                ssl._create_unverified_context(protocol=ssl.PROTOCOL_TLS_CLIENT)
+                if self.unverified_context
+                else ssl.create_default_context()
+            )
             if smtp_type == SMTPType.SSL:
                 server = SMTP_SSL(smtp_server, smtp_port, context=context)
             elif smtp_type == SMTPType.STARTTLS:

--- a/prefect_email/credentials.py
+++ b/prefect_email/credentials.py
@@ -86,6 +86,7 @@ class EmailServerCredentials(Block):
             keys from the built-in SMTPServer Enum members, like "gmail".
         smtp_type: Either "SSL", "STARTTLS", or "INSECURE".
         smtp_port: If provided, overrides the smtp_type's default port number.
+        unverified_context: Unverified context should be used or not. By default this is False.
 
     Example:
         Load stored email server credentials:

--- a/tests/test_credentials.py
+++ b/tests/test_credentials.py
@@ -92,3 +92,23 @@ def test_email_service_credentials_roundtrip_smtp_type_enum(smtp, smtp_type):
     assert credentials.smtp_type == SMTPType.STARTTLS
     server = credentials.get_server()
     assert server.port == 587
+
+
+@pytest.mark.parametrize("smtp_type", [SMTPType.STARTTLS, "STARTTLS", 587])
+@pytest.mark.parametrize("unverified_context", [True])
+def test_email_service_credentials_unverified_context(
+    smtp, smtp_type, unverified_context
+):
+    email_server_credentials = EmailServerCredentials(
+        smtp_server="us-smtp-outbound-1.mimecast.com",
+        smtp_type=smtp_type,
+        username="username",
+        password="password",
+        unverified_context=unverified_context,
+    )
+    email_server_credentials.save("email-credentials", overwrite=True)
+    credentials = EmailServerCredentials.load("email-credentials")
+    assert credentials.smtp_type == SMTPType.STARTTLS
+    assert credentials.unverified_context is True
+    server = credentials.get_server()
+    assert server.port == 587


### PR DESCRIPTION
<!-- Thanks for contributing 🎉! Please ensure the title neatly summarizes the proposed changes. -->

<!-- Overview -->

Closes [69](https://github.com/PrefectHQ/prefect-email/issues/69)
This PR is going to add support for unverified smtp servers to `prefect-email`.

### Example
```python
from prefect import flow
from prefect.context import get_run_context
from prefect_email import EmailServerCredentials, email_send_message

credentials = EmailServerCredentials(
    username="EMAIL-ADDRESS-PLACEHOLDER",
    password="PASSWORD-PLACEHOLDER",
    smtp_type="STARTTLS",
    unverified_context=True
)
credentials.save("email-server-credentials")

def notify_exc_by_email(exc):
    context = get_run_context()
    flow_run_name = context.flow_run.name
    email_server_credentials = EmailServerCredentials.load("email-server-credentials")
    email_send_message(
        email_server_credentials=email_server_credentials,
        subject=f"Flow run {flow_run_name!r} failed",
        msg=f"Flow run {flow_run_name!r} failed due to {exc}.",
        email_to=email_server_credentials.username,
    )

@flow
def example_flow():
    try:
        1 / 0
    except Exception as exc:
        notify_exc_by_email(exc)
        raise

example_flow()
```

### Screenshots
<!--
Any relevant screenshots
  - The updated docs page from `mkdocs serve`.
  - Output from running the example.
  - Service integration test results.
-->
![image](https://github.com/PrefectHQ/prefect-email/assets/44373191/8181a39a-5022-485a-8e39-be7f17f02063)

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [ ] References any related issue by including "Closes #<Issue Number>" or "Closes <Issue URL>".
  - If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect-email/issues/new/choose) first.
- [ ] Includes tests or only affects documentation.
- [ ] Passes `pre-commit` checks.
  - Run `pre-commit install && pre-commit run --all` locally for formatting and linting.
- [ ] Includes screenshots of documentation updates.
  - Run `mkdocs serve` view documentation locally.
- [ ] Summarizes PR's changes in [CHANGELOG.md](https://github.com/PrefectHQ/prefect-email/blob/main/CHANGELOG.md)
