### PR TITLE
fix authenticate bug for INSECURE servers

### DIFF
--- a/prefect_email/credentials.py
+++ b/prefect_email/credentials.py
@@ -191,7 +191,7 @@ class EmailServerCredentials(Block):
             elif smtp_type == SMTPType.STARTTLS:
                 server = SMTP(smtp_server, smtp_port)
                 server.starttls(context=context)
-            if self.username is not None:
-                server.login(self.username, self.password.get_secret_value())
+        if self.username is not None:
+            server.login(self.username, self.password.get_secret_value())
 
         return server


### PR DESCRIPTION
<!-- Thanks for contributing 🎉! Please ensure the title neatly summarizes the proposed changes. -->

<!-- Overview -->
Prefect-email is not supporting authentication on INSECURE mail servers. This PR will add that feature.

Closes
[80](https://github.com/PrefectHQ/prefect-email/issues/80)


### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [x] References any related issue by including "Closes #<Issue Number>" or "Closes <Issue URL>".
  - If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect-email/issues/new/choose) first.
- [ ] Includes tests or only affects documentation.
- [x] Passes `pre-commit` checks.
  - Run `pre-commit install && pre-commit run --all` locally for formatting and linting.
- [ ] Includes screenshots of documentation updates.
  - Run `mkdocs serve` view documentation locally.
